### PR TITLE
reworking the boost dependencies

### DIFF
--- a/builddir/linux-on-linux/Makeppfile
+++ b/builddir/linux-on-linux/Makeppfile
@@ -9,7 +9,8 @@
 # Some flags
 COMMON_FLAGS=
 CXXFLAGS+=${COMMON_FLAGS}
-LDFLAGS+=${COMMON_FLAGS} -static -ldl
+LDFLAGS+=${COMMON_FLAGS} -static
+LIBS+=-ldl
 
 # Our release
 RELEASE_BINARY_CLI=iteratedecks-cli

--- a/builddir/mingw32-on-linux/Makeppfile
+++ b/builddir/mingw32-on-linux/Makeppfile
@@ -6,6 +6,9 @@ CC:=${TOOLCHAIN_PREFIX}gcc
 CXX:=${TOOLCHAIN_PREFIX}g++
 LD:=${TOOLCHAIN_PREFIX}ld
 
+LIBS:=$(subst -lboost_system,-lboost_system-mt,${LIBS})
+LIBS:=$(subst -lboost_filesystem,-lboost_filesystem-mt,${LIBS})
+
 # Make it a static application, don't want to ship libraries to windows.
 COMMON_FLAGS=
 CXXFLAGS+=${COMMON_FLAGS}


### PR DESCRIPTION
Somehow linux ships with the non -mt versions of boost only. Apparently the -mt series was discontinued.
mingw however still has only the -mt version.

That should not affect the MSVC builds.
