### PR TITLE
I changed the way we use long options.

### DIFF
--- a/src/CLI2/cliOptions.cpp
+++ b/src/CLI2/cliOptions.cpp
@@ -167,6 +167,7 @@ namespace IterateDecks {
         , colorMode(Logger::COLOR_NONE)
         , printHelpAndExit(false)
         , surge(false)
+        , allowInvalidDecks(false)
         {
         }
     } // namespace CLI

--- a/src/CLI2/cliOptions.cpp
+++ b/src/CLI2/cliOptions.cpp
@@ -25,7 +25,10 @@ namespace IterateDecks {
                 CommentedOption const & commentedOption(options[i]);
                 option const & getOptPart(commentedOption.getOptPart);
                 std::string const & comment(commentedOption.comment);
-                bool const hasShortOpt(getOptPart.flag == NULL && getOptPart.val != 0);
+                bool const hasShortOpt(    getOptPart.flag == NULL
+                                        && getOptPart.val > 0
+                                        && getOptPart.val < 256
+                                      );
                 if(hasShortOpt) {
                     char const & shortOpt(getOptPart.val);
                     std::cout << "-" << shortOpt;

--- a/src/CLI2/cliOptions.hpp
+++ b/src/CLI2/cliOptions.hpp
@@ -28,8 +28,9 @@ using namespace IterateDecks::Core;
                 std::string comment;
             };
 
+            // FIXME: For now the constants are non printably chracaters, but this solution sucks.
             enum OptionConstant {
-                VERIFY = 256,
+                VERIFY = 1,
                 SEED,
                 COLOR,
                 ALLOW_INVALID_DECKS

--- a/src/CLI2/cliOptions.hpp
+++ b/src/CLI2/cliOptions.hpp
@@ -29,7 +29,7 @@ using namespace IterateDecks::Core;
             };
 
             enum OptionConstant {
-                VERIFY = 257,
+                VERIFY = 256,
                 SEED,
                 COLOR,
                 ALLOW_INVALID_DECKS

--- a/src/CLI2/cliOptions.hpp
+++ b/src/CLI2/cliOptions.hpp
@@ -29,7 +29,7 @@ using namespace IterateDecks::Core;
             };
 
             enum OptionConstant {
-                VERIFY = 256,
+                VERIFY = 257,
                 SEED,
                 COLOR,
                 ALLOW_INVALID_DECKS

--- a/src/CLI2/cliOptions.hpp
+++ b/src/CLI2/cliOptions.hpp
@@ -28,22 +28,31 @@ using namespace IterateDecks::Core;
                 std::string comment;
             };
 
-        /**
-         * Option table
-         */
+            enum OptionConstant {
+                VERIFY = 256,
+                SEED,
+                COLOR,
+                ALLOW_INVALID_DECKS
+            };
+
+            /**
+             * Option table
+             */
             static CommentedOption const options[] =
+                //  { name                   , has_arg        ,flag, val }, comment
                 { { { "number-of-iterations" , required_argument, 0, 'n' }, "sets the number of simulations to do" }
                 , { { "first-deck-is-ordered", no_argument      , 0, 'o' }, "marks the first deck (player deck) as ordered" }
                 , { { "achievement-index"    , required_argument, 0, 'a' }, "index (not id) of achievement. not sure where the difference is" }
-                , { { "verify"               , required_argument, 0, 0   }, "verify a result, provide an accepted range in the form <lower bound>:<upper bound>, like \"--verify 1:1\" if the deck should win all the time" }
+                , { { "verify"               , required_argument, 0, VERIFY }, "verify a result, provide an accepted range in the form <lower bound>:<upper bound>, like \"--verify 1:1\" if the deck should win all the time" }
                 , { { "verbose"              , no_argument      , 0, 'v' }, "verbose output" }
-                , { { "seed"                 , optional_argument, 0, 0   }, "set the seed, takes an optional argument. if none given use seed based on time." }
-                , { { "color"                , optional_argument, 0, 0   }, "color the output, currently only ANSI colors supported" }
+                , { { "seed"                 , optional_argument, 0, SEED }, "set the seed, takes an optional argument. if none given use seed based on time." }
+                , { { "color"                , optional_argument, 0, COLOR }, "color the output, currently only ANSI colors supported" }
                 , { { "help"                 , no_argument      , 0, 'h' }, "print help" }
                 , { { "surge"                , no_argument      , 0, 's' }, "first deck will surge" }
                 , { { "raid-id"              , required_argument, 0, 'r' }, "raid id" }
                 , { { "quest-id"             , required_argument, 0, 'Q' }, "quest id" }
                 , { { "mission-id"           , required_argument, 0, 'm' }, "mission id" }
+                , { { "allow-invalid-decks"  , no_argument      , 0, ALLOW_INVALID_DECKS }, "allows decks which are invalid (same unique twice, two legendaries)" }
                 };
 
 
@@ -118,6 +127,7 @@ using namespace IterateDecks::Core;
                 Logger::ColorMode colorMode;
                 bool printHelpAndExit;
                 bool surge;
+                bool allowInvalidDecks;
 
                 CliOptions();
             };

--- a/src/CLI2/cliParser.cpp
+++ b/src/CLI2/cliParser.cpp
@@ -136,11 +136,11 @@ namespace IterateDecks {
                             }
                             options.defenseDeck.setMission(missionId);
                         } break;
-                    case char(VERIFY): {
+                    case VERIFY: {
                             //std::clog << "verify" << std::endl;
                             options.verifyOptions = VerifyOptions(optarg);
                         } break;
-                     case char(SEED): {
+                     case SEED: {
                             if (optarg == NULL) {
                                 // no data, random seed
                                 options.seed = time(NULL);
@@ -152,11 +152,11 @@ namespace IterateDecks {
                                 }
                             }
                         } break;
-                    case char(COLOR): {
+                    case COLOR: {
                             // TODO better logic
                             options.colorMode = Logger::COLOR_ANSI;                            
                         } break;
-                    case char(ALLOW_INVALID_DECKS): {
+                    case ALLOW_INVALID_DECKS: {
                             options.allowInvalidDecks = true;
                         } break;
                     case '?':

--- a/src/CLI2/cliParser.cpp
+++ b/src/CLI2/cliParser.cpp
@@ -49,7 +49,10 @@ namespace IterateDecks {
             std::string shortOptions;
             for(unsigned int i = 0; i < numberOfOptions; i++) {
                 long_options[i] = options[i].getOptPart;
-                if (long_options[i].flag == NULL && long_options[i].val != 0) {
+                if (    long_options[i].flag == NULL
+                     && long_options[i].val != 0
+                     && long_options[i].val < 256
+                   ){
                     shortOptions += long_options[i].val;
                     if(long_options[i].has_arg == required_argument) {
                         shortOptions += ":";
@@ -71,18 +74,17 @@ namespace IterateDecks {
 
                 switch(c) {
                     case 'n': {
-                        std::stringstream ssNumberOfIterations(optarg);
-                        //std::stringstream ssNumberOfIterations("10");
-                        ssNumberOfIterations >> options.numberOfIterations;
-                        if(ssNumberOfIterations.fail()) {
-                            throw std::invalid_argument("-n --number-of-iterations requires an integer argument");
-                        }
-                            } break;
+                            std::stringstream ssNumberOfIterations(optarg);
+                            ssNumberOfIterations >> options.numberOfIterations;
+                            if(ssNumberOfIterations.fail()) {
+                                throw InvalidUserInputError("-n --number-of-iterations requires an integer argument");
+                            }
+                        } break;
                     case 'o': {
                             if (options.attackDeck.getType() == DeckArgument::HASH) {
                                 options.attackDeck.setOrdered(true);
                             } else {
-                                throw std::invalid_argument("ordered deck only makes sense for hash decks");
+                                throw InvalidUserInputError("ordered deck only makes sense for hash decks");
                             }
                         } break;
                     case 'a': {
@@ -90,7 +92,7 @@ namespace IterateDecks {
                             int achievementIndex;
                             ssAchievementIndex >> achievementIndex;
                             if(ssAchievementIndex.fail()) {
-                                throw std::invalid_argument ("-a --achievement-index requires an integer argument");
+                                throw InvalidUserInputError ("-a --achievement-index requires an integer argument");
                             }
                             if (achievementIndex >= 0) {
                                 options.achievementOptions.enableCheck(achievementIndex);
@@ -112,7 +114,7 @@ namespace IterateDecks {
                             int questId;
                             ssQuestId>> questId;
                             if(ssQuestId.fail()) {
-                                throw std::invalid_argument ("-Q --quest-id requires an integer argument");
+                                throw InvalidUserInputError ("-Q --quest-id requires an integer argument");
                             }
                             options.defenseDeck.setQuest(questId);
                         } break;
@@ -121,7 +123,7 @@ namespace IterateDecks {
                             int raidId;
                             ssRaidId>> raidId;
                             if(ssRaidId.fail()) {
-                                throw std::invalid_argument ("-r --raid-id requires an integer argument");
+                                throw InvalidUserInputError ("-r --raid-id requires an integer argument");
                             }
                             options.defenseDeck.setRaid(raidId);
                         } break;
@@ -130,43 +132,44 @@ namespace IterateDecks {
                             int missionId;
                             ssMissionId>> missionId;
                             if(ssMissionId.fail()) {
-                                throw std::invalid_argument ("-m --mission-id requires an integer argument");
+                                throw InvalidUserInputError ("-m --mission-id requires an integer argument");
                             }
                             options.defenseDeck.setMission(missionId);
                         } break;
+                    case VERIFY: {
+                            //std::clog << "verify" << std::endl;
+                            options.verifyOptions = VerifyOptions(optarg);
+                        } break;
+                     case SEED: {
+                            if (optarg == NULL) {
+                                // no data, random seed
+                                options.seed = time(NULL);
+                            } else {
+                                std::stringstream ssSeed(optarg);
+                                ssSeed >> options.seed;
+                                if (ssSeed.fail()) {
+                                    throw InvalidUserInputError("--seed requires an positive integer argument");
+                                }
+                            }
+                        } break;
+                    case COLOR: {
+                            // TODO better logic
+                            options.colorMode = Logger::COLOR_ANSI;                            
+                        } break;
+                    case ALLOW_INVALID_DECKS: {
+                            options.allowInvalidDecks = true;
+                        } break;
                     case '?':
-                        throw std::invalid_argument("no such option");
-                    case 0:
-                        switch(option_index) {
-                            case 3: {
-                                    options.verifyOptions = VerifyOptions(optarg);
-                                } break;
-                            case 5: {
-                                    if (optarg == NULL) {
-                                        // no data, random seed
-                                        options.seed = time(NULL);
-                                    } else {
-                                        std::stringstream ssSeed(optarg);
-                                        ssSeed >> options.seed;
-                                        if (ssSeed.fail()) {
-                                            throw std::invalid_argument("--seed requires an positive integer argument");
-                                        }
-                                    }
-                                } break;
-                            case 6: {
-                                    // TODO better logic
-                                    options.colorMode = Logger::COLOR_ANSI;
-                                } break;
-                            default: {
-                                    std::stringstream message;
-                                    message << "0 default: " << (int)option_index;
-                                    throw std::invalid_argument(message.str());
-                                } break;
+                        throw InvalidUserInputError("no such option");
+                    case 0: {
+                            std::stringstream message;
+                            message << "0 default: " << (int)option_index;
+                            throw InvalidUserInputError(message.str());
                         } break;
                     default: {
                             std::stringstream message;
                             message << "default: " << c;
-                            throw std::invalid_argument(message.str());
+                            throw InvalidUserInputError(message.str());
                         }
                 }
             }

--- a/src/CLI2/cliParser.cpp
+++ b/src/CLI2/cliParser.cpp
@@ -136,11 +136,11 @@ namespace IterateDecks {
                             }
                             options.defenseDeck.setMission(missionId);
                         } break;
-                    case VERIFY: {
+                    case char(VERIFY): {
                             //std::clog << "verify" << std::endl;
                             options.verifyOptions = VerifyOptions(optarg);
                         } break;
-                     case SEED: {
+                     case char(SEED): {
                             if (optarg == NULL) {
                                 // no data, random seed
                                 options.seed = time(NULL);
@@ -152,11 +152,11 @@ namespace IterateDecks {
                                 }
                             }
                         } break;
-                    case COLOR: {
+                    case char(COLOR): {
                             // TODO better logic
                             options.colorMode = Logger::COLOR_ANSI;                            
                         } break;
-                    case ALLOW_INVALID_DECKS: {
+                    case char(ALLOW_INVALID_DECKS): {
                             options.allowInvalidDecks = true;
                         } break;
                     case '?':


### PR DESCRIPTION
The old way, using indices in the option table, was very error prone, especially if options were added on different branches. Now we use integer constants > 255 to distinguish them.

This change might potentially break the windows getopt implementation, so please test it @MrHen
